### PR TITLE
Support dark color schemes in meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Systems Engineer | Portfolio Site</title>
     <meta name="description" content="Professional resume of a Systems Engineer with 16 years of IT experience" />
-    <meta name="color-scheme" content="light">
-    <meta name="supported-color-schemes" content="light">
+    <meta name="color-scheme" content="light dark">
+    <meta name="supported-color-schemes" content="light dark">
     <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0a0a0a">
     <!-- Tailwind + Icons -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" />


### PR DESCRIPTION
## Summary
- Expand color scheme meta tags to support both light and dark modes
- Provide theme-color metadata for dark mode to match site background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59b4eda90832cbe59a37ed766f051